### PR TITLE
20200904 androidのchromeでタップした時、青いハイライトが表示される #116

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -15,6 +15,7 @@ const theme = createMuiTheme({
 			'@global': {
 				html: {
 					backgroundColor: '#F2BE22',
+					'-webkit-tap-highlight-color': 'rgba(0,0,0,0)',
 				},
 				body: {
 					backgroundColor: '#FFFFFF',
@@ -22,9 +23,6 @@ const theme = createMuiTheme({
 				a: {
 					color: "#000000",
 					textDecoration: 'none',
-				},
-				div: {
-					'-webkit-tap-highlight-color': 'rgba(0,0,0,0)',
 				},
 			},
 		},


### PR DESCRIPTION
'-webkit-tap-highlight-color': 'rgba(0,0,0,0)',を追加